### PR TITLE
#22 bucket uses a static name, no random provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,3 +282,19 @@ This is the default file to load in terraform variables in bulk and run: `terraf
     - The `terraform.tfvars.json` file, if present.
     - Any `*.auto.tfvars` or `*.auto.tfvars.json` files, processed in lexical order of their filenames.
     - Any `-var` and `-var-file` options on the command line, in the order they are provided. (This includes variables set by an HCP Terraform workspace.)
+
+## Dealing With Configuration Drift
+### What happens if we lose our state file?
+If you lose your statefile, you most likley have to tear down all your cloud infrastructure manually.
+
+You can use terraform import but it won't work for all cloud resources. You need to check the terraform providers documentation for which resources support import.
+
+### Fix Missing Resources with Terraform Import
+`terraform import aws_s3_bucket.bucket bucket-name`
+
+[Terraform Import AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+
+### Fix Manual Configuration
+If someone goes and delete or modifies cloud resource manually through ClickOps.
+
+If we run Terraform plan is with attempt to put our infrstraucture back into the expected state fixing Configuration Drift

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,8 @@
-# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower = true
-  upper = false
-  length = 16
-  special = false
-}
-
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "website_bucket" {
   # Bucket Naming Rules
   #https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html?icmpid=docs_amazons3_console
-  bucket = random_string.bucket_name.result
+  bucket = var.bucket_name
   
   tags = {
     UserUuid = var.user_uuid

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket.bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,10 +7,6 @@ terraform {
 #     }
 #   }
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.6.2"
-    }
      aws = {
       source = "hashicorp/aws"
       version = "5.53.0"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="63e1d8c9-7eaf-4f06-a282-abfb03f80f1a"
+bucket_name="terrahouse-example-240624"

--- a/variables.tf
+++ b/variables.tf
@@ -6,3 +6,16 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket"
+  type        = string
+
+  validation {
+    condition     = (
+      length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+      can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
+    )
+    error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
+  }
+}


### PR DESCRIPTION
- Use TerraForm import.
- Purposely cause configuration drift via clickops, and correct state.