### PR TITLE
#26 enable static website hosting, upload index and error file via terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,3 +331,23 @@ module "terrahouse_aws" {
 ```
 
 [Modules Sources](https://developer.hashicorp.com/terraform/language/modules/sources)
+
+## Working with Files in Terraform
+### Fileexists function
+This is a built in terraform function to check the existance of a file.
+
+`condition = fileexists(var.error_html_filepath)`
+
+https://developer.hashicorp.com/terraform/language/functions/fileexists
+
+### Filemd5
+https://developer.hashicorp.com/terraform/language/functions/filemd5
+
+### Path Variable
+In terraform there is a special variable called `path` that allows us to reference local paths:
+
+path.module = get the path for the current module
+path.root = get the path for the root module
+[Special Path Variable](https://developer.hashicorp.com/terraform/language/expressions/references#filesystem-and-workspace-info)
+
+resource "aws_s3_object" "index_html" { bucket = aws_s3_bucket.website_bucket.bucket key = "index.html" source = "${path.root}/public/index.html" }

--- a/main.tf
+++ b/main.tf
@@ -12,4 +12,6 @@ module "terrahouse_aws" {
   source = "./modules/terrahouse_aws"
   user_uuid = var.user_uuid
   bucket_name = var.bucket_name
+  index_html_filepath = var.index_html_filepath
+  error_html_filepath = var.error_html_filepath
 }

--- a/modules/terrahouse_aws/main.tf
+++ b/modules/terrahouse_aws/main.tf
@@ -17,3 +17,34 @@ resource "aws_s3_bucket" "website_bucket" {
     UserUuid = var.user_uuid
   }
 }
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration
+resource "aws_s3_bucket_website_configuration" "website_configuration" {
+  bucket = aws_s3_bucket.website_bucket.bucket
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object
+resource "aws_s3_object" "index_html" {
+  bucket = aws_s3_bucket.website_bucket.bucket
+  key    = "index.html"
+  source = var.index_html_filepath
+
+  etag = filemd5(var.index_html_filepath)
+}
+
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object
+resource "aws_s3_object" "error_html" {
+  bucket = aws_s3_bucket.website_bucket.bucket
+  key    = "error.html"
+  source = var.error_html_filepath
+
+  etag = filemd5(var.error_html_filepath)
+}

--- a/modules/terrahouse_aws/outputs.tf
+++ b/modules/terrahouse_aws/outputs.tf
@@ -1,3 +1,7 @@
 output "bucket_name" {
   value = aws_s3_bucket.website_bucket.bucket
 }
+
+output "website_endpoint" {
+  value = aws_s3_bucket_website_configuration.website_configuration.website_endpoint
+}

--- a/modules/terrahouse_aws/variables.tf
+++ b/modules/terrahouse_aws/variables.tf
@@ -19,3 +19,23 @@ variable "bucket_name" {
     error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
   }
 }
+
+variable "index_html_filepath" {
+  description = "The file path for index.html"
+  type        = string
+
+  validation {
+    condition     = fileexists(var.index_html_filepath)
+    error_message = "The provided path for index.html does not exist."
+  }
+}
+
+variable "error_html_filepath" {
+  description = "The file path for error.html"
+  type        = string
+
+  validation {
+    condition     = fileexists(var.error_html_filepath)
+    error_message = "The provided path for error.html does not exist."
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "bucket_name" {
   description = "Bucket name for our static website hosting"
   value = module.terrahouse_aws.bucket_name
 }
+
+output "s3_website_endpoint" {
+  description = "S3 static website hosting endpoint"
+  value = module.terrahouse_aws.website_endpoint
+}

--- a/public/error.html
+++ b/public/error.html
@@ -1,0 +1,1 @@
+<h1>Error Found!!</h1>

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,2 +1,4 @@
 user_uuid="63e1d8c9-7eaf-4f06-a282-abfb03f80f1a"
 bucket_name="terrahouse-example-240624"
+index_html_filepath="/workspace/TerraTowns/public/index.html"
+error_html_filepath="/workspace/TerraTowns/public/error.html"

--- a/variables.tf
+++ b/variables.tf
@@ -5,3 +5,11 @@ variable "user_uuid" {
 variable "bucket_name" {
  type = string
 }
+
+variable "index_html_filepath" {
+  type = string
+}
+
+variable "error_html_filepath" {
+  type = string
+}


### PR DESCRIPTION
- Configured S3 bucket for static website hosting.
- Uploaded index.html and error.html files.
- Updated the outputs for static website URL.